### PR TITLE
fix compare in julia v1.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy: 
       matrix:
-        julia-version: ["1.6", "1.7"]
+        julia-version: ["1.7", "1.8"]
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 

--- a/src/momentintime.jl
+++ b/src/momentintime.jl
@@ -314,6 +314,9 @@ Base.:(+)(l::Integer, r::Union{MIT,Duration}) = oftype(r, l + Int(r))
 # For indexing and iterating TSeries it's more convenient to return Int rather than Duration, however
 # we choose to have the checks in place.
 
+# checkindex, however, needs to work with an Int
+Base.checkindex(::Type{Bool}, inds::AbstractUnitRange{<:MIT}, i::Int) = 1 <= i <= length(inds)
+
 # -------------------
 # one(x) is meant to be a dimensionless 1, so that's what we do
 Base.one(::Union{MIT,Duration,Type{<:MIT},Type{<:Duration}}) = Int(1)

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -102,11 +102,17 @@
         work2.A = TSeries(87Y, ones(4))
         work3 = Workspace()
         work3.A = TSeries(86Y, zeros(4))
+        work4 = Workspace()
+        work4.A = TSeries(86Y, zeros(300))
+        work5 = Workspace()
+        work5.A = TSeries(86Y, zeros(300))
 
         @test TimeSeriesEcon.compare_equal(work1, work2) == true
         @test TimeSeriesEcon.compare_equal(work1, work3) == false
+        @test TimeSeriesEcon.compare_equal(work4, work5) == true
         @test TimeSeriesEcon.compare(work1, work2) == true
         @test TimeSeriesEcon.compare(work1, work3) == false
+        @test TimeSeriesEcon.compare(work4, work5) == true
     end
 
     # reindexing


### PR DESCRIPTION
This fix adds a method for Base.checkindex for `UnitRange{MIT}` and `Int` inputs.

It also adds a test for comparison of tseries longer than 256, which was otherwise broken in Julia v 1.8