### PR TITLE
Fix `frequencyof(w::Workspace)`

### DIFF
--- a/src/workspaces.jl
+++ b/src/workspaces.jl
@@ -95,10 +95,17 @@ function _has_frequencyof(::Type{T}) where T
 end
 
 function frequencyof(w::Workspace; check=false)
-    iterable = (v for v in values(w) if _has_frequencyof(v))
-    freqs = mapreduce(frequencyof, vcat, iterable; init=Frequency[])
-    filter!(!isnothing, freqs)
-    unique!(freqs)
+    # recursively collect all frequencies in w.
+    freqs = []
+    for v in values(w)
+        if _has_frequencyof(v)
+            fr = frequencyof(v)
+            if !isnothing(fr)
+                push!(freqs, fr)
+            end
+        end
+    end
+    # return something or throw error based of number f frequencies found.
     if length(freqs) == 1
         return freqs[1]
     elseif check

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -204,4 +204,9 @@ end
     delete!(w, :d)
     @test frequencyof(w) <: Quarterly
     
+    w.w = Workspace(a=20Y, b=20Y-20Y)
+    w.b1 = @weval w b + a
+    w.α = @weval w  sin(pi) + w[:a] - w.a
+    @test frequencyof(w) isa Nothing
+    
 end

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -188,3 +188,20 @@ end
 
     # Note: no test for MVTSeries
 end
+
+@testset "frequencyof Workspaces" begin
+    
+    w = Workspace()
+    @test frequencyof(w) isa Nothing
+    @test_throws ArgumentError frequencyof(w; check=true)
+
+    push!(w, :a=>5, :b=>2020Q1)
+    push!(w, :c=>TSeries(w.b, rand(5)))
+    @test length(w) == 3
+    @test frequencyof(w) <: Quarterly
+    push!(w, :d => 20M1)
+    @test frequencyof(w) isa Nothing
+    delete!(w, :d)
+    @test frequencyof(w) <: Quarterly
+    
+end


### PR DESCRIPTION
`hasmethod(frequencyof, (typeof(v),))` doesn't work because `frequencyof` has a catch-all method for all types that simply throws an error.

![image](https://user-images.githubusercontent.com/12414774/219146911-ce490e3b-548c-4c13-88e9-367d19b650a0.png)

