### PR TITLE
Compare TSeries with different ranges respects ignoremissing

### DIFF
--- a/test/test_22.jl
+++ b/test/test_22.jl
@@ -9,5 +9,6 @@
     d2 = deepcopy(d1)
     d2.a = d1.a[2001Q1:2001Q1]
     d1.a = TSeries(1960Q1,randn(10))
-    @test compare(d1,d2; atol = 1e-8, quiet=true) 
+    @test !compare(d1,d2; atol = 1e-8, quiet=true)
+    @test compare(d1,d2; atol = 1e-8, quiet=true, ignoremissing=true)
 end

--- a/test/test_tseries.jl
+++ b/test/test_tseries.jl
@@ -662,6 +662,15 @@ end
     e = TSeries(89Y, [1.5, 1.6, NaN, 1.8])
     @test TimeSeriesEcon.compare(d, e, nans=true, quiet=true) == true
     
+    # compare with different ranges
+    A = TSeries(2020Q1, rand(20))
+    B = A[begin+4:end-4]
+    @test false == @compare A B quiet
+    @test true  == @compare A B quiet ignoremissing
+    @test false == @compare A B quiet trange=2019Q1:2025Q4
+    @test true  == @compare A B quiet trange=2019Q1:2025Q4 ignoremissing
+    @test true  == @compare A B quiet trange=2000Q1:2000Q4
+    @test true  == @compare A B quiet trange=2000Q1:2000Q4 ignoremissing
        
     #reindexing
     ts = TSeries(2020Q1,randn(10))

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -253,10 +253,12 @@ end
     @test (copyto!(dest, src); compare(src, dest, quiet=true))
     # dest has shorter range
     dest = MVTSeries(2020Q1 .+ (0:11), (:a, :b, :c))
-    @test (copyto!(dest, src); compare(src, dest, quiet=true))
+    @test (copyto!(dest, src); !compare(src, dest, quiet=true))
+    @test compare(src, dest, quiet=true, ignoremissing=true)
     # dest has longer range (not that compare uses the common range)
     dest = MVTSeries(2020Q1 .+ (0:40), (:a, :b, :c))
-    @test (copyto!(dest, src; range=2020Q1:2020Q1+19); compare(src, dest, quiet=true))
+    @test (copyto!(dest, src; range=2020Q1:2020Q1+19); compare(src, dest, quiet=true, ignoremissing=true))
+    @test !compare(src, dest, quiet=true)
     # dest is missing some variables 
     dest = MVTSeries(2020Q1 .+ (0:19), (:a, :c))
     @test (copyto!(dest, src); !compare(src, dest, quiet=true))


### PR DESCRIPTION
`@compare` macro and `compare` function take an argument `ignoremissing` which can be set to `true` or `false`.

Old behaviour for `TSeries` is that they are compared over their common range. If the common range is empty, the result is `true` otherwise the comparison is done by `isapprox` over the intersection of the two ranges.

New behaviour for `TSeries` takes into account `ignoremissing`, while treating values of `TSeries` objects outside their assigned range as missing.  Specifically, `ignoremissing=true` matches the old behaviour, while `ignoremissing=false` is stricter and returns `false` if the ranges don't match. 

