### PR TITLE
Improved dot-assignment for `MVTSeries`

### DIFF
--- a/src/mvtseries.jl
+++ b/src/mvtseries.jl
@@ -633,6 +633,7 @@ Base.dotview(sd::MVTSeries{F}, ind::TSeries{F,Bool}) where {F<:Frequency} = begi
 end
 
 
+Base.view(x::MVTSeries, J::_SymbolOneOrCollection) = view(x, axes(x, 1), J)
 Base.view(x::MVTSeries, ::Colon, J::_SymbolOneOrCollection) = view(x, axes(x, 1), J)
 Base.view(x::MVTSeries, I::_MITOneOrRange, ::Colon=Colon()) = view(x, I, axes(x, 2))
 Base.view(x::MVTSeries, ::Colon, ::Colon) = view(x, axes(x, 1), axes(x, 2))

--- a/src/mvtseries.jl
+++ b/src/mvtseries.jl
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, Bank of Canada
+# Copyright (c) 2020-2023, Bank of Canada
 # All rights reserved.
 
 using OrderedCollections
@@ -411,8 +411,12 @@ function Base.setproperty!(x::MVTSeries, name::Symbol, val)
         return copyto!(col, rng, val)
     elseif val isa Number
         return fill!(col.values, val)
+    elseif val isa MVTSeries
+        vcol = _col(val, name)
+        rng = intersect(rangeof(col), rangeof(vcol))
+        return copyto!(col, rng, vcol)
     else
-        return copyto!(col.values, val)
+        return col.values[:] = val
     end
 end
 
@@ -484,6 +488,13 @@ end
 @inline function Base.setindex!(x::MVTSeries, val, cols::_MVTSAxes2)
     inds = _colind(x, cols)
     setindex!(x.values, val, :, inds)
+end
+
+@inline function Base.setindex!(x::MVTSeries, val::MVTSeries, cols::_MVTSAxes2)
+    colinds = _colind(x, cols)
+    rng = intersect(rangeof(x), rangeof(val))
+    start, stop = _ind_range_check(x, rng)
+    setindex!(x.values, view(val, rng, cols), start:stop, colinds)
 end
 
 # ---- two arguments indexing

--- a/src/tsbroadcast.jl
+++ b/src/tsbroadcast.jl
@@ -132,7 +132,9 @@ function Base.copyto!(dest::TSeries, bc::Base.Broadcast.Broadcasted{Nothing})
 end
 
 function Base.Broadcast.dotview(t::TSeries, rng::AbstractUnitRange{<:MIT})
-    rng ⊆ eachindex(t) ? Base.maybeview(t, rng) :
-    Base.maybeview(resize!(t, union(eachindex(t), rng)), rng)
+    if rng ⊈ eachindex(t)
+        resize!(t, eachindex(t) ∪ rng)
+    end
+    return Base.maybeview(t, rng) 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@
 using Test
 using TimeSeriesEcon
 using Statistics
+using Random
 using Suppressor
 
 include("test_mit.jl")

--- a/test/test_mvtseries.jl
+++ b/test/test_mvtseries.jl
@@ -110,6 +110,10 @@ end
     @test a[1, 1] == 22
     @test_throws BoundsError a.c
     @test (a.a = TSeries(20Q1, 1:10); a.values[:, 1] == collect(1:10))
+    @test (a.a = 1; a.values[:, 1] == ones(10))
+    b = MVTSeries(rangeof(a), (:a, ), rand)
+    @test (a.a = b; a.values[:, 1] == b.values[:,1])
+    @test (a[:,:] .= 6ones(size(a)...); all(a.values .== 6))
 end
 
 @testset "MV" begin
@@ -269,7 +273,6 @@ end
         @test (sd[nms] = sd2; sd[rangeof(sd2),:].values == sd2.values)
         rand!(sd)
         @test (sd[nms] .= sd2; sd[rangeof(sd2),:].values == sd2.values)
-        
     end
 end
 

--- a/test/test_mvtseries.jl
+++ b/test/test_mvtseries.jl
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, Bank of Canada
+# Copyright (c) 2020-2023, Bank of Canada
 # All rights reserved.
 
 
@@ -116,7 +116,7 @@ end
     @test_throws ArgumentError MVTSeries(1M10, (:a, :b, :c), rand(10, 2))
     let nms = (:a, :b), dta = rand(20, 2),
         sd = MVTSeries(2000Q1, nms, copy(dta)),
-        dta2 = rand(size(dta)...)
+        dta2 = rand!(similar(dta))
 
         # if one argument is Colon, fall back on single argument indexing
         # getindex
@@ -176,7 +176,7 @@ end
         sd.a = zeros(size(dta, 1))
         @test sum(abs, sd.a.values) == 0
         @test_throws DimensionMismatch sd.a[:] = ones(length(sd.a) + 5)
-        @test_throws BoundsError sd.a = ones(length(sd.a) + 5)
+        @test_throws DimensionMismatch sd.a = ones(length(sd.a) + 5)
         # access to rows by MIT
         sd[:] = dta[:]
         @test sd[2000Q1] isa Vector{Float64}
@@ -252,10 +252,24 @@ end
         @test (myvar = [1, 2, 3, 4]; sd[2000Q1:2000Q4, :a] = myvar; sd[2000Q1:2000Q4, :a].values == myvar)
 
         # setindex from an MVTSeries to an MVTSeries
-        let sd2 = MVTSeries(2001Q1, nms, rand(8, length(nms)))
+        begin
+            sd2 = MVTSeries(2001Q1, nms, rand(8, length(nms)))
             sd[2001Q1:2001Q4, [:a, :b]] = sd2
             @test (sd[2001Q1:2001Q4, :].values == sd2[2001Q1:2001Q4, :].values)
+
         end
+
+        # https://github.com/bankofcanada/TimeSeriesEcon.jl/pull/49
+        # `sd[var] .= ...` should work the same as `sd[:,var] .= ...`
+        rand!(sd)
+        @test (sd[nms] = dta; sd.values == dta)
+        @test (sd[:a] .= dta2[:, 1]; sd[:b] = dta2[:, 2]; sd.values == dta2)
+        @test (sd[nms] .= dta; sd.values == dta)
+        @test (sd[nms] = dta2; sd.values == dta2)
+        @test (sd[nms] = sd2; sd[rangeof(sd2),:].values == sd2.values)
+        rand!(sd)
+        @test (sd[nms] .= sd2; sd[rangeof(sd2),:].values == sd2.values)
+        
     end
 end
 


### PR DESCRIPTION
Currently `data[vars] .= ...`  does not work and one is forced to do `data[:,vars] .= ...`.

This is inconsistent, because for reading (e.g., when indexing is done to the right of = or .=) `data[vars]` and `data[:,vars]` are identical.

It is also the case that `setindex!` works differently from dot-assignment: `data[var] = vec` works, while `data[var] .= vec` gives an error

This PR adds methods to `Base.dotview` to fix this.