### PR TITLE
Fix recipe for histograms plots

### DIFF
--- a/src/momentintime.jl
+++ b/src/momentintime.jl
@@ -784,7 +784,6 @@ Base.:(/)(a::MIT, b::Duration) = TimeSeriesEcon.mixed_freq_error(a, b)
 Base.:(/)(a::Duration{F}, b::Duration{F}) where {F<:Frequency} = Int(a) / Int(b)
 Base.:(/)(a::MIT{F}, b::Duration{F}) where {F<:Frequency} = (a - MIT{F}(0)) / b
 Base.promote_rule(::Type{<:Duration}, ::Type{T}) where {T<:AbstractFloat} = T
-(T::Type{<:AbstractFloat})(x::Duration) = convert(T, Int(x))
 
 # ----------------------------------------
 # 2.2 MIT{T} vector and dict support

--- a/src/momentintime.jl
+++ b/src/momentintime.jl
@@ -768,6 +768,8 @@ Base.one(::Union{MIT,Duration,Type{<:MIT},Type{<:Duration}}) = Int(1)
 # In the special case of YPFrequency we want the year to be the whole part and the period to be the fractional part. 
 (T::Type{<:AbstractFloat})(x::MIT{<:YPFrequency{N}}) where {N} = convert(T, ((y, p) = mit2yp(x); y + (p - 1) / N))
 Base.promote_rule(::Type{<:MIT}, ::Type{T}) where {T<:AbstractFloat} = T
+(T::Type{<:AbstractFloat})(x::Duration) = convert(T, Int(x))
+(T::Type{<:AbstractFloat})(x::Duration{<:YPFrequency{N}}) where {N} = convert(T, Int(x) / N)
 
 # frequency comparisons
 Base.isless(x::Type{<:Frequency}, y::Type{<:Frequency}) = isless(ppy(x), ppy(y))
@@ -862,6 +864,8 @@ Base.union(l::UnitRange{MIT{F}}, r::UnitRange{MIT{F}}) where {F<:Frequency} = mi
 
 # Base.issubset(l::UnitRange{<:MIT}, r::UnitRange{<:MIT}) = false
 # Base.issubset(l::UnitRange{MIT{F}}, r::UnitRange{MIT{F}}) where F <: Frequency = first(r) <= first(l) && last(l) <= last(r)
+
+Base.float(rng::UnitRange{MIT{F}}) where {F} = float(first(rng)):float(Duration{F}(1)):float(last(rng))
 
 #------------------------------
 # sort!() a list of MITs

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -59,24 +59,15 @@ end
 # This "user"-type recipe is for plotting multiple TSeries.
 # It calls the one_tseries recipe in a loop
 @recipe function many_tseries(ts::TSeries...)
+    # populate x with the range and y with t itself.
+    # divert to seriestype=:tseries (done in one_tseries() above), but
+    # keep track of the original seriestype, so we can restore it
     _org_st = get(plotattributes, :seriestype, :path)
-    if _org_st == :histogram
-        # histogram uses only the values
-        for t in ts
-            @series begin
-                values(t)
-            end
-        end
-    else
-        # populate x with the range and y with t itself.
-        # divert to seriestype=:tseries (done in one_tseries() above), but
-        # keep track of the original seriestype, so we can restore it
-        for t = ts
-            @series begin
-                seriestype := :tseries
-                _org_st := _org_st
-                (rangeof(t), t)
-            end
+    for t = ts
+        @series begin
+            seriestype := :tseries
+            _org_st := _org_st
+            (rangeof(t), t)
         end
     end
 end


### PR DESCRIPTION
This PR corrects the tseries plot recipe for different seriestypes.

The current implementation always plots TSeries with `seriestype=:path`, even if the TSeries were passed to `histogram()` or `scatter()`, for example. 

In this PR we preserve the original `seriestype`. We also handle correctly the case of `seriestype=:histogram`, which uses only the values, not the range.