### PR TITLE
enable support for mapslices for MVTSeries

### DIFF
--- a/src/mvtseries.jl
+++ b/src/mvtseries.jl
@@ -925,7 +925,7 @@ Returns an MVTseries when the dimensions of the result match the dimensions of A
 
 Returns a TSeries when the result is a vector of the same length as the range of A.
 
-Returns a the raw mapvalues result otherwise.
+Returns a Matrix otherwise.
 """
 function Base.mapslices(f, A::MVTSeries; dims) 
     res = mapslices(f, A.values; dims=dims)

--- a/src/mvtseries.jl
+++ b/src/mvtseries.jl
@@ -916,3 +916,27 @@ Base.getindex(sd::MVTSeries{F}, ind::TSeries{F,Bool}) where {F<:Frequency} = get
 Base.setindex!(sd::MVTSeries, ::Any, ::TSeries{F,Bool}) where {F<:Frequency} = mixed_freq_error(frequencyof(sd), F)
 Base.setindex!(sd::MVTSeries{F}, val, ind::TSeries{F,Bool}) where {F<:Frequency} = setindex!(_vals(sd), val, _vals(ind), :)
 
+"""
+mapslices(f, A::MVTSeries, dims)
+
+This functions as Base.mapslices with some specialized returns.
+
+Returns an MVTseries when the dimensions of the result match the dimensions of A.
+
+Returns a TSeries when the result is a vector of the same length as the range of A.
+
+Returns a the raw mapvalues result otherwise.
+"""
+function Base.mapslices(f, A::MVTSeries; dims) 
+    res = mapslices(f, A.values; dims=dims)
+    if size(res) == size(A)
+        res_mvts = similar(A)
+        res_mvts.values = res
+        return res_mvts
+    elseif size(res) == (size(A)[1], 1)
+        # one column
+        return TSeries(rangeof(A), res[:,1])
+    end
+    return res
+end
+

--- a/test/test_mvtseries.jl
+++ b/test/test_mvtseries.jl
@@ -850,10 +850,29 @@ using OrderedCollections
         @test a[c].values == [1, 2, 3, x[c]...]
     end
 
+    # pct, apct, ytypct
     ts = MVTSeries(2020Q1, (:y1, :y2), randn(10, 2))
     @test apct(ts).values == ((ts.values[2:10,:] ./ ts.values[1:9,:]) .^ 4 .- 1) * 100
     @test pct(ts).values ≈ ((ts.values[2:10,:] ./ ts.values[1:9,:]) .- 1) * 100
     @test ytypct(ts).values ≈ ((ts.values[5:10,:] ./ ts.values[1:6,:]) .- 1) * 100
+
+    # mapslices
+    ts = MVTSeries(2020Q1, (:y1, :y2), randn(10, 2))
+    res1 = mapslices(x -> x .+ 1, ts, dims=1)
+    res_matrix = copy(ts.values) .+ 1
+    res_mvts = MVTSeries(rangeof(ts), colnames(ts), res_matrix)
+    @test mapslices(x -> x .+ 1, ts, dims=1) == res_mvts
+    @test mapslices(x -> x .+ 1, ts, dims=2) == res_mvts
+
+    # one-column returns of the same length as ts return a TSeries
+    row_means = (ts.values[:,1] .+ ts.values[:,2] )./ 2
+    res_tseries = TSeries(rangeof(ts), row_means)
+    @test mapslices(mean, ts, dims=2) == res_tseries
+
+    # returns that don't fit just return a matrix
+    @test mapslices(mean, ts, dims=1) ==  mean(ts.values, dims=1)
+
+
 end
 
 @testset "hcat" begin


### PR DESCRIPTION
There is no guarantee that the result of mapslices matches the dimensions of the MVTSeries so there are two approaches to this:

1) just return whatever mapslices would return on A.values
2) makes some assumptions when the return has similar dimensions. 

I have taken the second approach. In particular, two cases apply:

* When the return matches the dimensions of the submitted MVTSeries, the result is an MVTSeries with the same range and columns.

* When the return matches the rowlength of the MVTSeries the result is a TSeries with the same range as the MVTSeries.

In all other cases the matrix return of mapslices is returned. Users can circumvent this logic by passing A.values instead of A.