### PR TITLE
Write and read special matrices, e.g. Diagonal, Symmetric, Transpose

### DIFF
--- a/test/test_dataecon.jl
+++ b/test/test_dataecon.jl
@@ -3,6 +3,7 @@
 
 using Dates
 using Random
+using LinearAlgebra
 
 DE = TimeSeriesEcon.DataEcon
 test_file = "test.daec"
@@ -236,6 +237,7 @@ end
 end
 
 @testset "DE 2d arrays" begin
+    types_map = Dict(Transpose => Matrix, Adjoint => Matrix)
     db = Workspace(
         mt1=zeros(3, 5),
         mt2=rand(Int32, 6, 8),
@@ -243,6 +245,13 @@ end
         sm2=[:this :is :What; :I :always :said],
         mv1=MVTSeries(2020Q1, (:a, :b, :c), rand(Float32, 8, 3)),
         mv2=MVTSeries(w"2020-01-17"5, (:a, :b), rand(Bool, 18, 2)),
+        diag=Diagonal(rand(17)),
+        tran=transpose(rand(22, 11)),
+        adj=adjoint(rand(ComplexF64, 13, 34)),
+        symu=Symmetric(rand(14, 14), :U),
+        syml=Symmetric(rand(14, 14), :L),
+        heru=Hermitian(rand(ComplexF32, 8, 8), :U),
+        herl=Hermitian(rand(ComplexF32, 8, 8), :L),
     )
 
     pid = DE.find_fullpath(de, "/2d", false)
@@ -265,8 +274,12 @@ end
     @test @compare db ldb quiet
 
     # their types are the same
-    @test @compare map(typeof, db) map(typeof, ldb) quiet
-
+    for (var, db_val) in pairs(db)
+        db_type = typeof(db_val)
+        db_base_type = eval(nameof(db_type))
+        ldb_base_type = get(types_map, db_base_type, db_type)
+        @test ldb[var] isa ldb_base_type
+    end
 end
 
 DE.new_catalog(de, "speedtest")


### PR DESCRIPTION
Resolve #55
This PR adds the ability to store and load 5 special matrix types from `LinearAlgebra`: `Diagonal`, `Symmetric`, `Hermitian`, `Transpose` and `Adjoint`. 

In each case the matrix is converted to a full matrix and stored. This is very inefficient for `Diagonal`, where only the diagonal is meaningful and somewhat inefficient for `Symmetric` and `Hermitian`. In order to do better than this we need support for this feature in [DataEcon](https://github.com/bankofcanada/DataEcon).

When loading, the original type is restored for `Diagonal`, `Symmetric` and `Hermitian`. In the case of `Transpose` and `Adjoint` the original type is lost and the object is loaded as a plain `Matrix`. In all cases the loaded object compares equal to the original.
