### PR TITLE
Fix bug in `mapslices`

### DIFF
--- a/src/mvtseries.jl
+++ b/src/mvtseries.jl
@@ -892,26 +892,24 @@ Base.getindex(sd::MVTSeries{F}, ind::TSeries{F,Bool}) where {F<:Frequency} = get
 Base.setindex!(sd::MVTSeries, ::Any, ::TSeries{F,Bool}) where {F<:Frequency} = mixed_freq_error(frequencyof(sd), F)
 Base.setindex!(sd::MVTSeries{F}, val, ind::TSeries{F,Bool}) where {F<:Frequency} = setindex!(_vals(sd), val, _vals(ind), :)
 
-"""
-mapslices(f, A::MVTSeries, dims)
+# """
+# mapslices(f, A::MVTSeries, dims)
 
-This functions as Base.mapslices with some specialized returns.
+# This functions as Base.mapslices with some specialized returns.
 
-Returns an MVTseries when the dimensions of the result match the dimensions of A.
+# Returns an MVTseries when the dimensions of the result match the dimensions of A.
 
-Returns a TSeries when the result is a vector of the same length as the range of A.
+# Returns a TSeries when the result is a vector of the same length as the range of A.
 
-Returns a Matrix otherwise.
-"""
+# Returns a Matrix otherwise.
+# """
 function Base.mapslices(f, A::MVTSeries; dims)
     res = mapslices(f, A.values; dims=dims)
     if size(res) == size(A)
-        res_mvts = similar(A)
-        res_mvts.values = res
-        return res_mvts
+        return MVTSeries(axes(A)..., res)
     elseif size(res) == (size(A)[1], 1)
         # one column
-        return TSeries(rangeof(A), res[:, 1])
+        return TSeries(rangeof(A), vec(res))
     end
     return res
 end

--- a/test/test_mvtseries.jl
+++ b/test/test_mvtseries.jl
@@ -1241,6 +1241,8 @@ using OrderedCollections
     # mapslices
     ts = MVTSeries(2020Q1, (:y1, :y2), randn(10, 2))
     res1 = mapslices(x -> x .+ 1, ts, dims=1)
+    @test res1 isa MVTSeries && axes(res1) == axes(ts)
+    @test res1.y1.values == res1.values[:,1]
     res_matrix = copy(ts.values) .+ 1
     res_mvts = MVTSeries(rangeof(ts), colnames(ts), res_matrix)
     @test mapslices(x -> x .+ 1, ts, dims=1) == res_mvts
@@ -1249,10 +1251,14 @@ using OrderedCollections
     # one-column returns of the same length as ts return a TSeries
     row_means = (ts.values[:, 1] .+ ts.values[:, 2]) ./ 2
     res_tseries = TSeries(rangeof(ts), row_means)
-    @test mapslices(mean, ts, dims=2) ≈ res_tseries
+    res2 = mapslices(mean, ts, dims=[2])
+    @test res2 isa TSeries && axes(res2) == (rangeof(ts),)
+    @test res2 ≈ res_tseries
 
     # returns that don't fit just return a matrix
-    @test mapslices(mean, ts, dims=1) ≈ mean(ts.values, dims=1)
+    res3 = mapslices(mean, ts, dims=1)
+    @test res3 isa Matrix
+    @test res3 ≈ mean(ts.values, dims=1)
 
 
 end


### PR DESCRIPTION
Assigning directly to `.values` in an `MVTSeries` instance breaks the link with the columns, which continue to point to the original contained. As a result, access using dot, e.g. `ts.y1`, does not equal access using indexing, e.g. `ts[rangeof(ts), :y1]`.

This PR fixes this issue. 
