### PR TITLE
Fix access and broadcasting of `MVTSeries` with `Vector{Bool}`

### DIFF
--- a/src/mvtseries.jl
+++ b/src/mvtseries.jl
@@ -587,7 +587,9 @@ end
 
 Base.view(x::MVTSeries, I::_FallbackType...) = view(_vals(x), _vals.(I)...)
 
-Base.view(x::MVTSeries, I::AbstractVector{Bool}) = view(_vals(x), _vals(I), :)
+Base.view(x::MVTSeries, I::AbstractVector{Bool}) = length(I) == size(x, 1) ? view(_vals(x), I, :) : view(_vals(x), I)
+Base.view(x::MVTSeries, I::AbstractVector{Bool}, J::_SymbolOneOrCollection) = view(x, rangeof(x)[I], J)
+
 
 Base.view(x::MVTSeries, J::_SymbolOneOrCollection) = view(x, axes(x, 1), J)
 Base.view(x::MVTSeries, ::Colon, J::_SymbolOneOrCollection) = view(x, axes(x, 1), J)

--- a/src/mvtseries/mvts_broadcast.jl
+++ b/src/mvtseries/mvts_broadcast.jl
@@ -170,7 +170,7 @@ end
 #############################################################################
 
 
-function Base.Broadcast.materialize!(::MVTSeriesStyle, dest, bc::Base.Broadcast.Broadcasted{Style}) where {Style <: Union{MVTSeriesStyle,TSeriesStyle}}
+function Base.Broadcast.materialize!(::MVTSeriesStyle, dest, bc::Base.Broadcast.Broadcasted{Style}) where {Style<:Union{MVTSeriesStyle,TSeriesStyle}}
     return copyto!(dest, Base.Broadcast.instantiate(bc))
 end
 
@@ -271,8 +271,16 @@ function Base.Broadcast.dotview(x::MVTSeries, rng::TSeries{F,Bool}, cols::Union{
     return Base.Broadcast.dotview(x, findall(rng), cols)
 end
 
-function Base.Broadcast.dotview(x::MVTSeries, rng::AbstractVector{Bool}, cols::Union{Colon,_SymbolOneOrCollection}=Colon())
-    return Base.Broadcast.dotview(x, rangeof(x)[rng], cols)
+function Base.Broadcast.dotview(x::MVTSeries, I::AbstractVector{Bool})
+    if length(I) == size(x, 1)
+        return Base.Broadcast.dotview(x, rangeof(x)[I], :)
+    else
+        return Base.Broadcast.dotview(_vals(x), I)
+    end
+end
+
+function Base.Broadcast.dotview(x::MVTSeries, I::AbstractVector{Bool}, J::Union{Colon,_SymbolOneOrCollection})
+    return Base.Broadcast.dotview(x, rangeof(x)[I], J)
 end
 
 # function Base.Broadcast.dotview(x::MVTSeries, rng::Union{MIT, AbstractUnitRange{<:MIT}}, cols::_SymbolOneOrCollection)

--- a/src/x13/X13.jl
+++ b/src/x13/X13.jl
@@ -74,18 +74,16 @@ function cleanup()
 end
 
 function get_cleanup_folders()
-    folder = mktempdir(; prefix="x13_", cleanup=true)
-    parent = joinpath(splitpath(folder)[1:end-1])
+    parent = tempdir()
     all_folders_and_files = readdir(parent, join=false)
     folders_to_remove = Vector{String}()
+    myuid = Libc.getuid()
     for f in all_folders_and_files
-        if findfirst("x13_", f) == 1:4 && isdir(joinpath(parent, f))
-            stats = stat(joinpath(parent,f))
-            if stats.uid == Libc.getuid()
-                path = joinpath(parent,f)
-                push!(folders_to_remove, path)
-            end
-        end
+        startswith(f, "x13_") || continue
+        fpath = joinpath(parent, f)
+        isdir(fpath) || continue
+        stat(fpath).uid == myuid || continue
+        push!(folders_to_remove, fpath)
     end
     
     return folders_to_remove


### PR DESCRIPTION
This PR fixes an issue with access and broadcasting with `MVTSeries` when the indexing is done via boolean vectors.

After this fix, the behaviour is as follows. 

* When using a single vector of booleans, the length could match either
  1) the number of columns, in which case it functions the same as if there were a second index `:`, selecting all columns, or 
  2) the total length of the `MVTSeries`, in which case it functions the same as if it were indexing the `.values`.
* The case of indexing with two boolean vectors is the same as for plain matrices - they each must match in length the number of rows and columns of the MVTSeries respectively. 