### PR TITLE
Various

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, Bank of Canada
+# Copyright (c) 2020-2024, Bank of Canada
 # All rights reserved.
 
 # overload matrix-matrix and matrix-vector operations
@@ -26,3 +26,5 @@ end
 Base.adjoint(A::MVTSeries) = adjoint(_vals(A))
 Base.adjoint(A::TSeries) = adjoint(_vals(A))
 
+Base.transpose(A::MVTSeries) = transpose(_vals(A))
+Base.transpose(A::TSeries) = transpose(_vals(A))

--- a/src/mvtseries.jl
+++ b/src/mvtseries.jl
@@ -226,6 +226,7 @@ _to_unitrange(x::MVTSeries) = rangeof(x)
 Base.size(x::MVTSeries) = size(_vals(x))
 Base.axes(x::MVTSeries) = (rangeof(x), [colnames(x)...])
 Base.axes1(x::MVTSeries) = rangeof(x)
+Base.parent(x::MVTSeries) = x.values
 
 const _MVTSAxes1 = AbstractUnitRange{<:MIT}
 const _MVTSAxes2 = Union{NTuple{N,Symbol},Vector{Symbol}} where {N}

--- a/src/tseries.jl
+++ b/src/tseries.jl
@@ -156,6 +156,7 @@ _to_unitrange(x::TSeries) = rangeof(x)
 Base.size(t::TSeries) = size(t.values)
 Base.axes(t::TSeries) = (firstdate(t):lastdate(t),)
 Base.axes1(t::TSeries) = firstdate(t):lastdate(t)
+Base.parent(t::TSeries) = t.values
 
 # Base.keys(t::TSeries) = rangeof(t)
 Base.findall(t::TSeries{F,Bool}) where {F<:Frequency} = firstdate(t) - 1 .+ findall(t.values)

--- a/src/various.jl
+++ b/src/various.jl
@@ -142,7 +142,7 @@ export compare, @compare
 
 @inline compare_equal(x, y; kwargs...) = isequal(x, y)
 @inline compare_equal(x::Number, y::Number; atol=0, rtol=atol > 0 ? 0.0 : √eps(), nans::Bool=false, kwargs...) = isapprox(x, y; atol, rtol, nans)
-@inline compare_equal(x::AbstractArray{<:Number}, y::AbstractArray{<:Number}; atol=0, rtol=atol > 0 ? 0.0 : √eps(), nans::Bool=false, kwargs...) = isapprox(x, y; atol, rtol, nans)
+@inline compare_equal(x::AbstractArray{<:Number}, y::AbstractArray{<:Number}; atol=0, rtol=atol > 0 ? 0.0 : √eps(), nans::Bool=false, kwargs...) = size(x) == size(y) && isapprox(x, y; atol, rtol, nans)
 function compare_equal(x::TSeries, y::TSeries; ignoremissing=false, trange::Union{Nothing,AbstractUnitRange{<:MIT}}=nothing, atol=0, rtol=atol > 0 ? 0.0 : √eps(), nans::Bool=false, kwargs...)
     if frequencyof(x) != frequencyof(y)
         return false

--- a/test/test_various.jl
+++ b/test/test_various.jl
@@ -82,11 +82,11 @@ end
     @test (tv[tm] .= -1.0; tm == (tv .< 0.0))
 
     @test (tv[tb] == tv.values[tb.values, :])
-    @test (tv[tb,:] == tv.values[tb.values, :])
+    @test (tv[tb, :] == tv.values[tb.values, :])
     @test (tv[tb] = -1000 * ones(sum(tb), 3); sum(tv[tb]) == -1000 * 3 * sum(tb))
-    @test (tv[tb,:] = -2000 * ones(sum(tb), 3); sum(tv[tb]) == -2000 * 3 * sum(tb))
+    @test (tv[tb, :] = -2000 * ones(sum(tb), 3); sum(tv[tb]) == -2000 * 3 * sum(tb))
     @test (tv[tb] .= -3000; sum(tv[tb]) == -3000 * 3 * sum(tb))
-    @test (tv[tb,:] .= -4000; sum(tv[tb]) == -4000 * 3 * sum(tb))
+    @test (tv[tb, :] .= -4000; sum(tv[tb]) == -4000 * 3 * sum(tb))
 
 
 end
@@ -116,8 +116,8 @@ end
         NaN 10.1 10.1 10.1 10.1]
     @test isapprox(c, mat1, nans=true)
     @test isapprox(mat1, c, nans=true)
-    @test isapprox(c.a, mat1[:,1], nans=true)
-    @test isapprox(mat1[:,1], c.a, nans=true)
+    @test isapprox(c.a, mat1[:, 1], nans=true)
+    @test isapprox(mat1[:, 1], c.a, nans=true)
     d = overlay(b, a)
     @test c isa MVTSeries
     @test frequencyof(d) == frequencyof(b) == frequencyof(a)
@@ -138,4 +138,25 @@ end
             10.1 10.1 10.1 10.1 NaN
             10.1 10.1 10.1 10.1 NaN
             10.1 10.1 10.1 10.1 NaN], nans=true)
+end
+
+@testset "misc" begin
+
+    o = ones(20, 3)
+    X = MVTSeries(2000Y, (:x, :y, :z), o)
+
+    @test parent(X) === o
+    @test parent(X.x) === view(o, :, 1)
+
+    @test transpose(X) === transpose(o)
+    @test transpose(X.x) === transpose(view(o, :, 1))
+
+    Z = MVTSeries(2000Y, (:x, :y, :z), ones(15, 3))
+
+    @test compare(X.values, Z.values, quiet=true) == false
+    @test compare(X, Z, quiet=true, ignoremissing=false) == false
+    @test compare(X, Z, quiet=true, ignoremissing=true) == true
+
+    @test Base.axes1(X) === axes(X,1)
+
 end


### PR DESCRIPTION
This PR includes the addition of a few internal methods to better integrate `TSeries` and `MVTSeries` with Julia's internal machinery for Arrays.

* `Base.parent` method for `TSeries` and `MVTSeries`
* `Base.transpose` method for `MVTSeries`
* fix for `compare` - when comparing matrices of different sizes, it now returns false instead of crashing
