### PR TITLE
Fix `rangeof_span` for `Workspaces`

### DIFF
--- a/src/workspaces.jl
+++ b/src/workspaces.jl
@@ -95,7 +95,13 @@ rangeof(w::AbstractWorkspace; method=intersect) = (
     iterable = (v for v in values(w) if applicable(rangeof, v));
     mapreduce(rangeof, method, iterable)
 )
-_to_unitrange(x::AbstractWorkspace) = rangeof(x)
+
+# _to_unitrange is only used in the implementation of rangeof_span, which requires union of ranges. 
+_to_unitrange(x::AbstractWorkspace) = rangeof_span(
+    Iterators.map(
+        _to_unitrange, values(x)
+    )...
+)
 
 _has_frequencyof(::Type{<:AbstractWorkspace}) = true
 _has_frequencyof(::T) where {T} = _has_frequencyof(T)

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -294,3 +294,17 @@ end
 
     @test compare(map(sum, w), Workspace(keys(w) .=> map(sum, values(w))), quiet=true)
 end
+
+@testset "rangeof_span(Workspace)" begin
+    w = Workspace(
+        a = 2020Q1:2025Q3,
+        b = zeros(2019Q1:2023Q2),
+        c = [2018Q1, 2021Q2],
+        d = MVTSeries(1992Q2, (:a,:b), ones(30, 2)),
+        e = Workspace(
+            a = TSeries(1995Q3+2, rand(22))
+        )
+    )
+    @test rangeof_span(w) isa UnitRange
+    @test rangeof_span(w) == 1992Q2:2025Q3
+end


### PR DESCRIPTION
rangeof_span falls back on rangeof, which returns the intersection. We need rangeof_span to return the union.