### PR TITLE
Fix `recursive=true` for converting to `Workspace` from `AbstractDict`.

### DIFF
--- a/src/various.jl
+++ b/src/various.jl
@@ -107,10 +107,10 @@ end
 #### merge! and merge
 
 @inline Base.empty!(w::Workspace) = (empty!(w._c); w)
-@inline Base.merge!(w::Workspace, others::Union{Workspace,<:AbstractDict}...) = (
-    merge!(_c(w), map(_c, others)...);
-    w
-)
+function Base.merge!(w::Workspace, others::Union{Workspace, AbstractDict}...) 
+    merge!(_c(w), Iterators.map(_c ∘ _dict_to_workspace, others)...);
+    return w
+end
 @inline Base.merge(w::Workspace, others::Union{Workspace,<:AbstractDict}...) = merge!(Workspace(), w, others...)
 
 #### compare and @compare 

--- a/src/workspaces.jl
+++ b/src/workspaces.jl
@@ -37,9 +37,12 @@ end
 _c(w::AbstractWorkspace) = getfield(w, :_c)
 
 _dict_to_workspace(x) = x
-_dict_to_workspace(x::AbstractDict) = Workspace(x)
+_dict_to_workspace(x::AbstractDict) = Workspace(x; recursive=true)
 function Workspace(fromdict::AbstractDict; recursive=false)
     w = Workspace()
+    if Base.haslength(fromdict)
+        Base.sizehint!(_c(w), length(fromdict))
+    end
     convert_value = recursive ? _dict_to_workspace : identity
     for (key, value) in fromdict
         w[Symbol(key)] = convert_value(value)

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -248,7 +248,7 @@ end
 
 @testset "merge" begin
     a = Workspace(a=6, b=7, q=8)
-    ka = copy(keys(a))
+    ka = Set(keys(a))
     @test (empty!(a); isempty(a))
     a = Workspace(a=6, b=7, q=8)
     @test (merge!(a, Workspace(z=12)); keys(a) == union(ka, (:z,)) && a.z == 12)


### PR DESCRIPTION
Also, merging an `AbstractDict` into a `Workspace` now
converts the dict keys to `Symbol`s.