### PR TITLE
Fix error when indexing `StepRange` with `begin` and `end`

### DIFF
--- a/src/momentintime.jl
+++ b/src/momentintime.jl
@@ -861,6 +861,8 @@ Base.:(:)(start::MIT{F}, step::Duration{F}, stop::MIT{F}) where {F<:Frequency} =
 
 Base.length(rng::UnitRange{<:MIT}) = convert(Int, last(rng) - first(rng) + 1)
 Base.step(rng::UnitRange{<:MIT}) = convert(Int, 1)
+Base.length(rng::StepRange{<:MIT}) = length(StepRange{Int,Int}(rng.start,rng.step,rng.stop))
+Base.step(rng::StepRange{<:MIT}) = step(StepRange{Int,Int}(rng.start,rng.step,rng.stop))
 
 """
     rangeof_span(args...)

--- a/test/test_mit.jl
+++ b/test/test_mit.jl
@@ -130,6 +130,8 @@ end
         @test first(rng) <= m <= last(rng)
         @test rng[i] == m
     end
+    @test rng[begin] == first(rng)
+    @test rng[end] == last(rng)
     @test_throws ArgumentError 2020Q1:2020M12
 
     @test rangeof_span(3U:5U, 4U:6U) === 3U:6U
@@ -138,16 +140,20 @@ end
     # step ranges
     sr1 = 1Q1:1Q3-1Q1:4Q4
     @test length(sr1) == 8
+    # @test length(sr1) isa Int
     @test step(sr1) == 2
+    # @test step(sr1) isa Int
     @test first(sr1) == 1Q1
     @test last(sr1) == 4Q3
+    @test sr1[begin] == first(sr1) && sr1[end] == last(sr1)
     @test collect(sr1) == [1Q1, 1Q3, 2Q1, 2Q3, 3Q1, 3Q3, 4Q1, 4Q3]
-
+    
     sr2 = 1Q1:2:4Q4
     @test length(sr2) == 8
     @test step(sr2) == 2
     @test first(sr2) == 1Q1
     @test last(sr2) == 4Q3
+    @test sr2[begin] == first(sr1) && sr1[end] == last(sr1)
     @test collect(sr2) == [1Q1, 1Q3, 2Q1, 2Q3, 3Q1, 3Q3, 4Q1, 4Q3]
 
     @test_throws ArgumentError 1Q2:2:5U


### PR DESCRIPTION
```julia
julia> (2020Q1:2:2022Q4)[end]
ERROR: promotion of types Duration{Quarterly{3}} and Duration{Quarterly{3}} failed to change any arguments
Stacktrace:
 [1] error(::String, ::String, ::String)
   @ Base ./error.jl:44
 [2] sametype_error(input::Tuple{Duration{Quarterly{3}}, Duration{Quarterly{3}}})
   @ Base ./promotion.jl:417
 [3] not_sametype(x::Tuple{Duration{…}, Duration{…}}, y::Tuple{Duration{…}, Duration{…}})
   @ Base ./promotion.jl:411
 [4] *(a::Duration{Quarterly{3}}, b::Duration{Quarterly{3}})
   @ Base ./int.jl:1067
 [5] getindex(v::StepRange{MIT{Quarterly{3}}, Duration{Quarterly{3}}}, i::Duration{Quarterly{3}})
   @ Base ./range.jl:944
 [6] top-level scope
   @ REPL[3]:1
Some type information was truncated. Use `show(err)` to see complete types.
```