### PR TITLE
Fix speed issue with workspace eltype

### DIFF
--- a/src/workspaces.jl
+++ b/src/workspaces.jl
@@ -72,6 +72,10 @@ function Base.eltype(w::AbstractWorkspace)
     end
     return Pair{Symbol,ET}
 end
+function Base.eltype(w::AbstractWorkspace)
+    ET = isempty(w) ? Any : reduce(Base.promote_typeof, values(w))
+    return Pair{Symbol,ET}
+end
 
 Base.push!(w::AbstractWorkspace, args...; kwargs...) = (push!(_c(w), args..., (k => v for (k, v) in kwargs)...); w)
 Base.delete!(w::AbstractWorkspace, args...; kwargs...) = (delete!(_c(w), args...; kwargs...); w)

--- a/src/workspaces.jl
+++ b/src/workspaces.jl
@@ -65,14 +65,6 @@ MacroTools.@forward Workspace._c (Base.isempty, Base.keys, Base.haskey, Base.val
 MacroTools.@forward Workspace._c (Base.iterate, Base.get, Base.get!,)
 
 function Base.eltype(w::AbstractWorkspace)
-    ET = isempty(w) ? Any : try
-        Base.promote_typeof(values(w)...)
-    catch
-        Any
-    end
-    return Pair{Symbol,ET}
-end
-function Base.eltype(w::AbstractWorkspace)
     ET = isempty(w) ? Any : reduce(Base.promote_typeof, values(w))
     return Pair{Symbol,ET}
 end

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -318,3 +318,26 @@ end
     @test rangeof_span(w) isa UnitRange
     @test rangeof_span(w) == 1992Q2:2025Q3
 end
+
+@testset "eltype workspace" begin
+    w1 = Workspace()
+    @test eltype(w1) == Pair{Symbol,Any}
+    
+    w2 = Workspace()
+    w2.ts1 = TSeries(2020Q1, randn(10))
+    w2.ts2 = TSeries(2020Q2, randn(10))
+    @test eltype(w2) == Pair{Symbol, TSeries{Quarterly{3}, Float64, Vector{Float64}}}
+
+    w3 = Workspace()
+    w3.ts1 = TSeries(2020Q1, randn(10))
+    w3.a = 22.2
+    w3.b = 2022Y
+    @test eltype(w3) == Pair{Symbol,Any}
+
+    w4 = Workspace()
+    w4.ts1 = TSeries(2020Q1, randn(10))
+    w4.ts2 = TSeries(2020M2, randn(10))
+    @test eltype(w4) == Pair{Symbol, TSeries{F, Float64, Vector{Float64}} where F<:Frequency}
+    @test eltype(w4) <: Pair{Symbol, <:TSeries}
+
+end


### PR DESCRIPTION
This PR removes the use of splatting from the eltype for workspaces. 

Issue context: https://support.juliacomputing.com/support/tickets/8282 

Also removes a try/catch added in: https://github.com/bankofcanada/TimeSeriesEcon.jl/commit/de56e093d52e502fd6bbda21d31c7987ca8b8a3f . Tests pass with workspaces containing mixed frequencies.